### PR TITLE
feat: ✨ enhance YouTube video ID extraction and improve thumbnail handling

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -79,6 +79,7 @@
 		"unrs",
 		"wbmp",
 		"WPCC",
-		"xvid"
+		"xvid",
+		"youtu"
 	]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -79,7 +79,6 @@
 		"unrs",
 		"wbmp",
 		"WPCC",
-		"xvid",
-		"youtu"
+		"xvid"
 	]
 }

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
 		"@sparticuz/chromium": "138.0.2",
 		"clsx": "2.1.1",
 		"cross-fetch": "4.1.0",
+		"get-video-id": "4.1.7",
 		"ky": "1.8.2",
 		"next": "15.4.5",
 		"puppeteer-core": "24.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       cross-fetch:
         specifier: 4.1.0
         version: 4.1.0
+      get-video-id:
+        specifier: 4.1.7
+        version: 4.1.7
       ky:
         specifier: 1.8.2
         version: 1.8.2
@@ -3984,6 +3987,10 @@ packages:
   get-uri@6.0.5:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
     engines: {node: '>= 14'}
+
+  get-video-id@4.1.7:
+    resolution: {integrity: sha512-bYHXe3BTbFbiViuNFyfFnZPnSDVWBu5N06p35LW7dD/ul4O1sdPSs3Brw8U/m5JlQUnkj3tht3luSz0k05vEYg==}
+    engines: {node: '>=16'}
 
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
@@ -10733,6 +10740,10 @@ snapshots:
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
+
+  get-video-id@4.1.7:
+    dependencies:
+      '@babel/runtime': 7.28.2
 
   giget@2.0.0:
     dependencies:

--- a/src/app/try/route.ts
+++ b/src/app/try/route.ts
@@ -117,7 +117,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
 					const { id: videoId } = getVideoId(urlStr);
 					if (videoId) {
-						logger.info("Video ID found, changing YOUTUBE URL to YOUTUBE_THUMBNAIL_URL");
+						logger.info(
+							"Video ID found, changing YOUTUBE URL to YOUTUBE_THUMBNAIL_URL",
+						);
 						urlStr = `${YOUTUBE_THUMBNAIL_URL}/${videoId}/maxresdefault.jpg`;
 					}
 				}
@@ -201,10 +203,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 						}
 
 						// YouTube: Get thumbnail image only if it is an video else take entire page screenshot
-						if (
-							urlStr.includes(YOUTUBE) &&
-							urlStr.includes(YOUTUBE_THUMBNAIL_URL)
-						) {
+						if (urlStr.includes(YOUTUBE_THUMBNAIL_URL)) {
 							logger.info("YouTube: Looking for thumbnail image for video");
 
 							const img = await page.$("img");

--- a/src/app/try/route.ts
+++ b/src/app/try/route.ts
@@ -117,7 +117,7 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
 					const { id: videoId } = getVideoId(urlStr);
 					if (videoId) {
-						logger.info("Video ID found redirecting to YOUTUBE_THUMBNAIL_URL");
+						logger.info("Video ID found, changing YOUTUBE URL to YOUTUBE_THUMBNAIL_URL");
 						urlStr = `${YOUTUBE_THUMBNAIL_URL}/${videoId}/maxresdefault.jpg`;
 					}
 				}

--- a/src/app/try/route.ts
+++ b/src/app/try/route.ts
@@ -104,14 +104,18 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 			try {
 				logger.info(`Navigation attempt ${attempt}`, { url: urlStr });
 
+				let videoId = null;
 				if (urlStr.includes(YOUTUBE)) {
 					logger.info("YouTube URL detected, fetching metadata");
 
 					// here we use the getMetadata function to get the metadata of the video
 					metaData = await getMetadata(page, urlStr, logger);
 					// Extract video ID from URL
-					const videoIdMatch = /(?:v=|\/)([\w-]{11})/.exec(urlStr);
-					const videoId = videoIdMatch?.[1];
+					const videoIdMatch =
+						/(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|shorts\/|v\/|.*[?&]v=))([\w-]{11})/.exec(
+							urlStr,
+						);
+					videoId = videoIdMatch?.[1];
 					if (videoId) {
 						urlStr = `https://img.youtube.com/vi/${videoId}/maxresdefault.jpg`;
 					}
@@ -200,7 +204,10 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 							logger.info("YouTube: Looking for thumbnail image");
 
 							const img = await page.$("img");
-							if (img) screenshotTarget = img;
+							if (img && videoId) {
+								logger.debug("Thumbnail image found");
+								screenshotTarget = img;
+							}
 						}
 
 						if (screenshotTarget) {

--- a/src/utils/puppeteer/utils.ts
+++ b/src/utils/puppeteer/utils.ts
@@ -7,3 +7,4 @@ export const X = "x.com";
 export const INSTAGRAM = "instagram.com";
 export const YOUTUBE = "youtube.com";
 export const TWITTER = "twitter.com";
+export const YOUTUBE_THUMBNAIL_URL = "https://img.youtube.com/vi";


### PR DESCRIPTION
- we redirect to https://img.youtube.com/vi/${videoId}/maxresdefault.jpg to get the thumbnail of the video, and scope the img tag and take screenshot
-  if the link is not a video form the youtube then we fall back to the normal screenshot
-  added a condition that only the urls is YOUTUBE and YOUTUBE_THUMBNAIL_URL take the screenshot of the img tag
- used get-video-id package https://www.npmjs.com/package/get-video-id to get the. videoId from the url
Tested Url's:
1. https://youtube.com/
2. https://www.youtube.com/gaming
3. https://www.youtube.com/channel/UCZtmNrG53nmbq-Ww2VJrxEQ/live
4. https://www.youtube.com/@LOVELYGTA5
5. https://www.youtube.com/shorts/NvnIHvLvNWc
6. https://www.youtube.com/watch?v=mxDZ8rsJWEg
<img width="2880" height="2400" alt="image" src="https://github.com/user-attachments/assets/0c09838a-b3b8-4753-972e-cbeaf1888f5d" />
<img width="2880" height="2400" alt="image" src="https://github.com/user-attachments/assets/9bfa22f8-ec6a-45fb-8d31-1a166fc5af5a" />
<img width="2880" height="2400" alt="image" src="https://github.com/user-attachments/assets/63caaaff-e832-408c-a561-e481455c7ff4" />
<img width="2880" height="2400" alt="image" src="https://github.com/user-attachments/assets/54e986e3-76b5-4265-ac40-8c781b6a9cce" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/8c4cebf6-dad7-49ad-8ba6-f4117abe145d" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/df0c83a0-b891-41fc-94a8-49c1d3e53a9c" />



