### PR TITLE
refactor: :recycle: change the div selection method

### DIFF
--- a/src/lib/puppeteer/screenshot/getInstagramPostReelScreenshot.ts
+++ b/src/lib/puppeteer/screenshot/getInstagramPostReelScreenshot.ts
@@ -148,11 +148,11 @@ export async function getInstagramPostReelScreenshot(
 				timeout: 5000,
 			});
 
-			const divs = await page.$$("article  div[role='button']");
+			const divs = await page.$$("article > div");
 			logger.debug("Searching for article divs", { found: divs.length });
 
 			if (divs.length > 2) {
-				const targetDiv = divs[2];
+				const targetDiv = divs[1];
 
 				await targetDiv.waitForSelector("img", { timeout: 5000 });
 


### PR DESCRIPTION
change the div selection method because sometimes the images in the first div, when the we select the div role='button'

ex links:
1. https://www.instagram.com/principal.studio/p/DJ_6MrKRd8v/?img_index=9
2. https://www.instagram.com/principal.studio/p/DIRMlq8RAOO/?img_index=1