### PR TITLE
refactor(puppeteer): enable GPU option

### DIFF
--- a/src/lib/puppeteer/browser/launchBrowser.ts
+++ b/src/lib/puppeteer/browser/launchBrowser.ts
@@ -76,7 +76,7 @@ const VERCEL_ONLY_ARGS = [
 
 	// Disable GPU features to save memory
 	// Disables GPU hardware acceleration which isn't available in serverless
-	"--disable-gpu",
+	// "--disable-gpu",
 	// Disables GPU sandbox to reduce overhead in headless mode
 	"--disable-gpu-sandbox",
 	// Disables canvas hardware acceleration to save memory


### PR DESCRIPTION
This pull request makes a small change to the browser launch arguments in `src/lib/puppeteer/browser/launchBrowser.ts`. The change comments out the `--disable-gpu` flag, which previously disabled GPU hardware acceleration.

* Commented out the `--disable-gpu` flag in `VERCEL_ONLY_ARGS` to potentially allow GPU hardware acceleration.